### PR TITLE
Remove default pipe

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -8,14 +8,19 @@ import (
 )
 
 func main() {
-	mux := http.NewServeMux()
+	// create a default handler pipe
+	hp := janice.New(janice.ErrorHandling(), janice.ErrorLogging(janice.ErrorLogger))
 
-	mux.Handle("/", janice.New(middleware).Then(func(w http.ResponseWriter, r *http.Request) error {
+	mux := http.NewServeMux()
+	mux.Handle("/", hp.Append(middleware).Then(func(w http.ResponseWriter, r *http.Request) error {
 		fmt.Fprintf(w, "hello handler!\n")
 		return nil
 	}))
 
-	http.ListenAndServe(":8080", janice.Default().Then(janice.Wrap(mux)))
+	// create a default mux pipe
+	mp := janice.New(janice.Recovery(janice.ErrorLogger), janice.RequestLogging(janice.RequestLogger))
+
+	http.ListenAndServe(":8080", mp.Then(janice.Wrap(mux)))
 }
 
 func middleware(n janice.HandlerFunc) janice.HandlerFunc {

--- a/janice_test.go
+++ b/janice_test.go
@@ -4,70 +4,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
-	"log"
+ 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stevecallear/janice"
 )
-
-func TestDefault(t *testing.T) {
-	rl := janice.RequestLogger
-	el := janice.ErrorLogger
-
-	defer func() {
-		janice.RequestLogger = rl
-		janice.ErrorLogger = el
-	}()
-
-	b := new(bytes.Buffer)
-
-	janice.RequestLogger = janice.NewLogger(log.New(b, "", 0), "")
-	janice.ErrorLogger = janice.NewLogger(log.New(b, "", 0), "")
-
-	tests := []struct {
-		panic error
-		err   error
-		code  int
-	}{
-		{
-			code: http.StatusOK,
-		},
-		{
-			panic: errors.New("panic"),
-			code:  http.StatusInternalServerError,
-		},
-		{
-			err:  errors.New("error"),
-			code: http.StatusInternalServerError,
-		},
-		{
-			err:  janice.NewStatusError(http.StatusNotFound, errors.New("error")),
-			code: http.StatusNotFound,
-		},
-	}
-
-	for tn, tt := range tests {
-		h := janice.Default().Then(func(w http.ResponseWriter, r *http.Request) error {
-			if tt.panic != nil {
-				panic(tt.panic)
-			}
-
-			return tt.err
-		})
-
-		rec := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", "/", nil)
-
-		h.ServeHTTP(rec, req)
-
-		if rec.Code != tt.code {
-			t.Errorf("Default(%d); got %d, expected %d", tn, rec.Code, tt.code)
-		}
-	}
-}
 
 func TestNew(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Errors don't flow across combinations of `Then` and `Wrap` (e.g. across a router), which can result in subtle bugs in the middleware flow. For example:

```
mux.Handle("/", janice.New().Then(errorReturningHandler))
http.ListenAndServe(":8080",  janice.Default().Then(janice.Wrap(mux))
```

In this case errors returned by `errorReturningHandler` will be swallowed when it is wrapped by the call to `Then`. This means that no errors will be logged or handled by the `janice.Default()` pipe, instead only a 500 error code will be returned to indicate that something has gone wrong.

Flowing errors across combinations of `Then` and `Wrap` is feasible, but for the short term this PR simply removes the default pipe, encouraging the use of pre and post-router pipes.