### PR TITLE
Tweak logger construction

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -2,14 +2,13 @@ package janice
 
 import (
 	"encoding/json"
-	"io"
 	"log"
 	"os"
 	"time"
 )
 
 // DefaultLogger is the default logger
-var DefaultLogger = NewLogger(os.Stdout)
+var DefaultLogger = NewLogger(log.New(os.Stdout, "", 0))
 
 type (
 	// Fields represents a set of log fields
@@ -27,9 +26,9 @@ type (
 )
 
 // NewLogger returns a new logger
-func NewLogger(w io.Writer) Logger {
+func NewLogger(l *log.Logger) Logger {
 	return &logger{
-		Logger: log.New(w, "", 0),
+		Logger: l,
 	}
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -3,6 +3,7 @@ package janice_test
 import (
 	"bytes"
 	"encoding/json"
+	"log"
 	"math"
 	"testing"
 
@@ -66,7 +67,7 @@ func TestLogger(t *testing.T) {
 				}
 			}()
 
-			tt.fn(janice.NewLogger(b))
+			tt.fn(janice.NewLogger(log.New(b, "", 0)))
 		}()
 
 		e := readLogEntry(b.Bytes())

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -3,6 +3,7 @@ package janice_test
 import (
 	"bytes"
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -106,7 +107,7 @@ func TestRecovery(t *testing.T) {
 		}
 
 		b := new(bytes.Buffer)
-		l := janice.NewLogger(b)
+		l := janice.NewLogger(log.New(b, "", 0))
 
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/", nil)
@@ -186,7 +187,7 @@ func TestRequestLogging(t *testing.T) {
 		}
 
 		b := new(bytes.Buffer)
-		l := janice.NewLogger(b)
+		l := janice.NewLogger(log.New(b, "", 0))
 
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(tt.method, tt.rpath, nil)
@@ -280,7 +281,7 @@ func TestErrorLogging(t *testing.T) {
 		}
 
 		b := new(bytes.Buffer)
-		l := janice.NewLogger(b)
+		l := janice.NewLogger(log.New(b, "", 0))
 
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/", nil)


### PR DESCRIPTION
Updates `NewLogger` to accept a `log.Logger` rather than an `io.Writer` as this is what is used under the hood anyway. This allows consumers to use the same logger for janice as for the rest of their app.