### PR TITLE
Refactor tests

### DIFF
--- a/janice.go
+++ b/janice.go
@@ -12,7 +12,7 @@ type (
 
 // New returns a new middleware pipe
 func New(m ...MiddlewareFunc) MiddlewareFunc {
-	return combine(m)
+	return merge(m)
 }
 
 // Wrap wraps the specified handler, allowing it to be used with middleware
@@ -25,13 +25,12 @@ func Wrap(h http.Handler) HandlerFunc {
 
 // Append appends the specified middleware funcs to the pipe
 func (m MiddlewareFunc) Append(n ...MiddlewareFunc) MiddlewareFunc {
-	return combine(append([]MiddlewareFunc{m}, n...))
+	return merge(append([]MiddlewareFunc{m}, n...))
 }
 
 // Then terminates the middleware pipe with the specified handler func
 func (m MiddlewareFunc) Then(h HandlerFunc) http.Handler {
 	h = m(h)
-
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := h(w, r); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -39,12 +38,11 @@ func (m MiddlewareFunc) Then(h HandlerFunc) http.Handler {
 	})
 }
 
-func combine(m []MiddlewareFunc) MiddlewareFunc {
+func merge(m []MiddlewareFunc) MiddlewareFunc {
 	return func(h HandlerFunc) HandlerFunc {
 		for i := len(m) - 1; i >= 0; i-- {
 			h = m[i](h)
 		}
-
 		return h
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -7,8 +7,15 @@ import (
 	"time"
 )
 
-// DefaultLogger is the default logger
-var DefaultLogger = NewLogger(log.New(os.Stdout, "", 0))
+var (
+	// Now returns the current time
+	Now = func() time.Time {
+		return time.Now()
+	}
+
+	// DefaultLogger is the default logger
+	DefaultLogger = NewLogger(log.New(os.Stdout, "", 0))
+)
 
 type (
 	// Fields represents a set of log fields
@@ -19,7 +26,6 @@ type (
 		Info(Fields)
 		Error(Fields)
 	}
-
 	logger struct {
 		*log.Logger
 	}
@@ -32,22 +38,22 @@ func NewLogger(l *log.Logger) Logger {
 	}
 }
 
+// Info logs the specified fields at info level
 func (l *logger) Info(f Fields) {
 	l.log("info", f)
 }
 
+// Error logs the specified fields at error level
 func (l *logger) Error(f Fields) {
 	l.log("error", f)
 }
 
 func (l *logger) log(level string, f Fields) {
 	f["level"] = level
-	f["time"] = time.Now().UTC().Format(time.RFC3339)
-
+	f["time"] = Now().UTC().Format(time.RFC3339)
 	b, err := json.Marshal(f)
 	if err != nil {
 		panic(err)
 	}
-
 	l.Println(string(b))
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -6,298 +6,346 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stevecallear/janice"
 )
 
 func TestNewStatusError(t *testing.T) {
 	tests := []struct {
+		name string
 		code int
 		err  error
 	}{
 		{
+			name: "should return the correct error",
 			code: http.StatusInternalServerError,
 			err:  errors.New("error"),
 		},
 		{
+			name: "should return the correct code",
 			code: http.StatusBadRequest,
 			err:  errors.New("error"),
 		},
 	}
-
-	for tn, tt := range tests {
-		err := janice.NewStatusError(tt.code, tt.err)
-
-		if err.Code != tt.code {
-			t.Errorf("NewStatusError(%d); got %d, expected %d", tn, err.Code, tt.code)
-		}
-		if err.Error() != tt.err.Error() {
-			t.Errorf("NewStatusError(%d); got %s, expected %s", tn, err.Error(), tt.err.Error())
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			err := janice.NewStatusError(tt.code, tt.err)
+			if err.Error() != tt.err.Error() {
+				st.Errorf("got %s, expected %s", err.Error(), tt.err.Error())
+			}
+			if err.Code != tt.code {
+				st.Errorf("got %d, expected %d", err.Code, tt.code)
+			}
+		})
 	}
 }
 
 func TestStatusCode(t *testing.T) {
 	tests := []struct {
-		err error
-		exp int
+		name string
+		err  error
+		exp  int
 	}{
 		{
-			exp: http.StatusOK,
+			name: "should return 200 if error is nil",
+			exp:  http.StatusOK,
 		},
 		{
-			err: errors.New("error"),
-			exp: http.StatusInternalServerError,
+			name: "should return 500 if error is not nil",
+			err:  errors.New("error"),
+			exp:  http.StatusInternalServerError,
 		},
 		{
-			err: janice.NewStatusError(http.StatusNotFound, errors.New("error")),
-			exp: http.StatusNotFound,
+			name: "should return code if error is status error",
+			err:  janice.NewStatusError(http.StatusNotFound, errors.New("error")),
+			exp:  http.StatusNotFound,
 		},
 	}
-
-	for tn, tt := range tests {
-		act := janice.StatusCode(tt.err)
-
-		if act != tt.exp {
-			t.Errorf("StatusCode(%d); got %d, expected %d", tn, act, tt.exp)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			act := janice.StatusCode(tt.err)
+			if act != tt.exp {
+				st.Errorf("got %d, expected %d", act, tt.exp)
+			}
+		})
 	}
 }
 
 func TestRecovery(t *testing.T) {
+	now := time.Now()
 	tests := []struct {
+		name  string
 		panic error
 		err   error
 		code  int
-		log   map[string]string
+		exp   map[string]string
 	}{
 		{
+			name: "should do nothing if there is no panic",
 			code: http.StatusOK,
-			log:  map[string]string{},
+			exp:  map[string]string{},
 		},
 		{
+			name: "should do nothing if there is an error",
+			err:  errors.New("error"),
+			code: http.StatusOK,
+			exp:  map[string]string{},
+		},
+		{
+			name:  "should recover and log the panic",
 			panic: errors.New("panic"),
 			code:  http.StatusInternalServerError,
-			log: map[string]string{
+			exp: map[string]string{
 				"type":  "recovery",
 				"level": "error",
 				"error": "panic",
+				"time":  now.UTC().Format(time.RFC3339),
 			},
 		},
-		{
-			err:  errors.New("error"),
-			code: http.StatusOK,
-			log:  map[string]string{},
-		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			withTime(now, func() {
+				h := func(w http.ResponseWriter, r *http.Request) error {
+					if tt.panic != nil {
+						panic(tt.panic)
+					}
+					return tt.err
+				}
+				b := new(bytes.Buffer)
+				l := janice.NewLogger(log.New(b, "", 0))
 
-	for tn, tt := range tests {
-		h := func(w http.ResponseWriter, r *http.Request) error {
-			if tt.panic != nil {
-				panic(tt.panic)
-			}
+				rec := httptest.NewRecorder()
+				req := httptest.NewRequest("GET", "/", nil)
 
-			if tt.err != nil {
-				return tt.err
-			}
-
-			return nil
-		}
-
-		b := new(bytes.Buffer)
-		l := janice.NewLogger(log.New(b, "", 0))
-
-		rec := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", "/", nil)
-
-		err := janice.Recovery(l)(h)(rec, req)
-
-		if err != tt.err {
-			t.Errorf("Recovery(%d); got %v, expected %v", tn, err, tt.err)
-		}
-		if rec.Code != tt.code {
-			t.Errorf("Recovery(%d); got %d, expected %d", tn, rec.Code, tt.code)
-		}
-
-		e := readLogEntry(b.Bytes())
-		if !e.hasValues(tt.log) {
-			t.Errorf("Recovery(%d); got %v, expected %v", tn, e, tt.log)
-		}
+				err := janice.Recovery(l)(h)(rec, req)
+				if err != tt.err {
+					st.Errorf("got %v, expected %v", err, tt.err)
+				}
+				if rec.Code != tt.code {
+					st.Errorf("got %d, expected %d", rec.Code, tt.code)
+				}
+				act := parseLogEntry(b.Bytes())
+				if !reflect.DeepEqual(act, tt.exp) {
+					st.Errorf("got %v, expected %v", act, tt.exp)
+				}
+			})
+		})
 	}
 }
 
 func TestRequestLogging(t *testing.T) {
-	tests := []struct {
+	type request struct {
 		method string
-		code   int
-		rpath  string
-		npath  string
-		err    error
-		log    map[string]string
+		path   string
+	}
+	type result struct {
+		code int
+		path string
+	}
+	now := time.Now()
+	tests := []struct {
+		name string
+		req  request
+		res  result
+		err  error
+		exp  map[string]string
 	}{
 		{
-			method: "GET",
-			code:   http.StatusOK,
-			rpath:  "/",
-			npath:  "/",
-			log: map[string]string{
-				"type":   "request",
-				"level":  "info",
-				"method": "GET",
-				"path":   "/",
-				"code":   strconv.Itoa(http.StatusOK),
+			name: "should log the method",
+			req: request{
+				method: "GET",
+				path:   "/",
+			},
+			res: result{
+				code: http.StatusOK,
+				path: "/",
+			},
+			exp: map[string]string{
+				"type":    "request",
+				"level":   "info",
+				"time":    now.UTC().Format(time.RFC3339),
+				"host":    "example.com",
+				"method":  "GET",
+				"path":    "/",
+				"code":    strconv.Itoa(http.StatusOK),
+				"written": "0",
 			},
 		},
 		{
-			method: "POST",
-			code:   http.StatusBadRequest,
-			rpath:  "/",
-			npath:  "/",
-			log: map[string]string{
-				"type":   "request",
-				"level":  "info",
-				"method": "POST",
-				"path":   "/",
-				"code":   strconv.Itoa(http.StatusBadRequest),
+			name: "should log the status code",
+			req: request{
+				method: "POST",
+				path:   "/",
+			},
+			res: result{
+				code: http.StatusBadRequest,
+				path: "/",
+			},
+			exp: map[string]string{
+				"type":    "request",
+				"level":   "info",
+				"time":    now.UTC().Format(time.RFC3339),
+				"host":    "example.com",
+				"method":  "POST",
+				"path":    "/",
+				"code":    strconv.Itoa(http.StatusBadRequest),
+				"written": "0",
 			},
 		},
 		{
-			method: "GET",
-			code:   http.StatusOK,
-			rpath:  "/resource/",
-			npath:  "/",
-			log: map[string]string{
-				"type":   "request",
-				"level":  "info",
-				"method": "GET",
-				"path":   "/resource/",
-				"code":   strconv.Itoa(http.StatusOK),
+			name: "should log the path",
+			req: request{
+				method: "GET",
+				path:   "/resource/",
+			},
+			res: result{
+				code: http.StatusOK,
+				path: "/",
+			},
+			exp: map[string]string{
+				"type":    "request",
+				"level":   "info",
+				"time":    now.UTC().Format(time.RFC3339),
+				"host":    "example.com",
+				"method":  "GET",
+				"path":    "/resource/",
+				"code":    strconv.Itoa(http.StatusOK),
+				"written": "0",
 			},
 		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			withTime(now, func() {
+				h := func(w http.ResponseWriter, r *http.Request) error {
+					r.URL.Path = tt.res.path
+					w.WriteHeader(tt.res.code)
+					return nil
+				}
+				b := new(bytes.Buffer)
+				l := janice.NewLogger(log.New(b, "", 0))
 
-	for tn, tt := range tests {
-		h := func(w http.ResponseWriter, r *http.Request) error {
-			r.URL.Path = tt.npath
+				rec := httptest.NewRecorder()
+				req := httptest.NewRequest(tt.req.method, tt.req.path, nil)
 
-			w.WriteHeader(tt.code)
-			return nil
-		}
-
-		b := new(bytes.Buffer)
-		l := janice.NewLogger(log.New(b, "", 0))
-
-		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(tt.method, tt.rpath, nil)
-
-		err := janice.RequestLogging(l)(h)(rec, req)
-
-		if err != tt.err {
-			t.Errorf("RequestLogging(%d); got %v, expected %v", tn, err, tt.err)
-		}
-		if rec.Code != tt.code {
-			t.Errorf("RequestLogging(%d); got %d, expected %d", tn, rec.Code, tt.code)
-		}
-
-		e := readLogEntry(b.Bytes())
-		if !e.hasValues(tt.log) {
-			t.Errorf("RequestLogging(%d); got %v, expected %v", tn, e, tt.log)
-		}
+				err := janice.RequestLogging(l)(h)(rec, req)
+				if err != tt.err {
+					st.Errorf("got %v, expected %v", err, tt.err)
+				}
+				if rec.Code != tt.res.code {
+					st.Errorf("got %d, expected %d", rec.Code, tt.res.code)
+				}
+				act := parseLogEntry(b.Bytes())
+				delete(act, "duration") // ignore the duration field to avoid flakiness
+				if !reflect.DeepEqual(act, tt.exp) {
+					st.Errorf("got %v, expected %v", act, tt.exp)
+				}
+			})
+		})
 	}
 }
 
 func TestErrorHandling(t *testing.T) {
 	tests := []struct {
+		name string
 		err  error
 		code int
 		exp  string
 	}{
 		{
+			name: "should return 200 if the error is nil",
 			code: http.StatusOK,
 		},
 		{
+			name: "should log and return 500 if the error is not nil",
 			err:  errors.New("error"),
 			code: http.StatusInternalServerError,
 			exp:  "error\n",
 		},
 		{
+			name: "should log and return code if the error is status error",
 			err:  janice.NewStatusError(http.StatusBadRequest, errors.New("error")),
 			code: http.StatusBadRequest,
 			exp:  "error\n",
 		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			h := janice.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+				return tt.err
+			})
 
-	for tn, tt := range tests {
-		h := janice.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-			return tt.err
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/", nil)
+
+			err := janice.ErrorHandling()(h)(rec, req)
+			if err != nil {
+				t.Errorf("got %v, expected nil", err)
+			}
+			if rec.Code != tt.code {
+				t.Errorf("got %d, expected %d", rec.Code, tt.code)
+			}
+			act := new(bytes.Buffer)
+			act.ReadFrom(rec.Body)
+			if act.String() != tt.exp {
+				t.Errorf("got %s, expected %s", act.String(), tt.exp)
+			}
 		})
-
-		rec := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", "/", nil)
-
-		err := janice.ErrorHandling()(h)(rec, req)
-
-		b := new(bytes.Buffer)
-		b.ReadFrom(rec.Body)
-
-		if err != nil {
-			t.Errorf("ErrorHandling(%d); got %v, expected nil", tn, err)
-		}
-		if rec.Code != tt.code {
-			t.Errorf("ErrorHandling(%d); got %d, expected %d", tn, rec.Code, tt.code)
-		}
-		if b.String() != tt.exp {
-			t.Errorf("ErrorHandling(%d); got %s, expected %s", tn, b.String(), tt.exp)
-		}
 	}
 }
 
 func TestErrorLogging(t *testing.T) {
+	now := time.Now()
 	tests := []struct {
+		name string
 		err  error
 		code int
-		log  map[string]string
+		exp  map[string]string
 	}{
 		{
+			name: "should not write a log entry if the error is nil",
 			code: http.StatusOK,
-			log:  map[string]string{},
+			exp:  map[string]string{},
 		},
 		{
+			name: "should write a log entry if the error is not nil",
 			err:  errors.New("error"),
 			code: http.StatusOK,
-			log: map[string]string{
+			exp: map[string]string{
 				"type":  "error",
 				"level": "error",
 				"error": "error",
+				"time":  now.UTC().Format(time.RFC3339),
 			},
 		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			h := func(w http.ResponseWriter, r *http.Request) error {
+				return tt.err
+			}
+			b := new(bytes.Buffer)
+			l := janice.NewLogger(log.New(b, "", 0))
 
-	for tn, tt := range tests {
-		h := func(w http.ResponseWriter, r *http.Request) error {
-			return tt.err
-		}
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/", nil)
 
-		b := new(bytes.Buffer)
-		l := janice.NewLogger(log.New(b, "", 0))
-
-		rec := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", "/", nil)
-
-		err := janice.ErrorLogging(l)(h)(rec, req)
-
-		if err != tt.err {
-			t.Errorf("ErrorLogging(%d); got %v, expected %v", tn, err, tt.err)
-		}
-		if rec.Code != tt.code {
-			t.Errorf("ErrorLogging(%d); got %d, expected %d", tn, rec.Code, tt.code)
-		}
-
-		e := readLogEntry(b.Bytes())
-		if !e.hasValues(tt.log) {
-			t.Errorf("ErrorLogging(%d); got %v, expected %v", tn, e, tt.log)
-		}
+			err := janice.ErrorLogging(l)(h)(rec, req)
+			if err != tt.err {
+				st.Errorf("got %v, expected %v", err, tt.err)
+			}
+			if rec.Code != tt.code {
+				st.Errorf("got %d, expected %d", rec.Code, tt.code)
+			}
+			act := parseLogEntry(b.Bytes())
+			if !reflect.DeepEqual(act, tt.exp) {
+				st.Errorf("got %v, expected %v", act, tt.exp)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Various tidying:
* Update all tests to use named sub-tests and remove the horrible numeric index that was being used to identify failures.
* Improve test case clarity by favouring functions over magic values
* General (subjective) improvements to formatting, whitespace and naming.